### PR TITLE
Fig 9 MSE 90th percentile calcs and censoring

### DIFF
--- a/code/viz/exhibit_fns/09_compare_ffb_fcb_mse.R
+++ b/code/viz/exhibit_fns/09_compare_ffb_fcb_mse.R
@@ -15,13 +15,15 @@ percent_change <- function(x1, x2) {
 
 compare_ffb_fcb_mse <- function() {
   
-  # Load FRR predictions (ffb) ####
+  # Load FRR predictions ####
   
   mods_to_load <- 
     c("ffb", "fcb", "ncb") %>%
     purrr::set_names()
   
   full_predictions <-
+    # Load in FFB, FCB, and NCB prediction dataframes, but keep them separate 
+    # for now
     map(
       mods_to_load,
       loadResults,
@@ -32,14 +34,16 @@ compare_ffb_fcb_mse <- function() {
       mutate(fips = str_sub(sid, 1, 5)) %>%
         select(fips, model, sid, .pred, log_priceadj_ha)
     )
+
   
-  # MSE in added counties
+  # Brief analysis aside to produce stats reported in the paper ----------------
+  
+  # 1. MSE in added counties
   full_predictions$ffb %>%
     filter(! fips %in% full_predictions$fcb$fips) %>%
     calc_mse()
-
   
-  # Compare fcb to ffb MSE across common parcels
+  # 2. Compare fcb to ffb MSE across common parcels
   ffb_ncb_common_parcels <-
     common_parcels(full_predictions[c("ffb", "ncb")])
   
@@ -52,30 +56,54 @@ compare_ffb_fcb_mse <- function() {
     map(calc_mse) %>%
     map("mean_mse")
   
-  # 15 percent change referenced in abstract and end of results section
+  # 15 percent change referenced in abstract and end of results section ->
     percent_change(x1 = mse_across_common_parcels$ncb, 
                    x2 = mse_across_common_parcels$ffb)
     
+  # ----------------------------------------------------------------------------  
     
+  
+  # Back to mapping FFB and FCB relative county coverage -----------------------    
     full_predictions <-
+      # Grab FFB and FCB from the list of model prediction dataframes...
       full_predictions[c("ffb", "fcb")] %>%
+      # ...and row-bind them together, filling in missing county observations with
+      # NAs if one model includes that county but the other does not
       data.table::rbindlist(fill = TRUE) %>%
+      
+      # Calculate MSE 
       mutate(sq_error = (.pred - log_priceadj_ha)^2) %>%
       group_by(fips, model) %>%
       mutate(mse = mean(sq_error)) %>%
       ungroup() %>%
       select(model, fips, mse) %>%
+      
+      # Clean up model names
       mutate(model = if_else(model=="ffb", "Full FRR", "Full County")) %>%
       distinct()
     
     frr_missing_obs <-
       full_predictions %>%
+      
+      # We start with a column called "model" that identifies which model 
+      # a given prediction came up. Now we pivot that column, along with the 
+      # MSE values, to create 2 columns: one for FFB and one for FCB, each 
+      # containing the corresponding MSE values in that county. This allows us
+      # to determine which counties are not in the FRR model's test set (which
+      # is where these predictions come from) but are by definition included in
+      # the county's test set, since each county gets its own test and train set
+      # Only a handful of counties are absent from the FRR test set in this way. 
+      # We plot them at black and note the quirk of our modeling approach in the 
+      # figure caption
       pivot_wider(
         names_from = model,
         values_from = mse
       ) %>%
+      # This filter call keeps only those *counties* which are missing from the 
+      # FRR model in the manner described in the above comment
       filter(is.na(`Full FRR`)) %>%
       select(fips) %>%
+      # Join to the counties shapefile for later mapping in black.
       left_join(us_counties,
                 by = "fips") %>%
       st_as_sf()
@@ -87,13 +115,23 @@ compare_ffb_fcb_mse <- function() {
     
     mutate(mse_b = cut(mse, breaks = c(0, 0.5, 1, 5, 40)))
   
+  # The 90th percentile is calculated relative to the vector of *all* county
+  # MSEs. That is, the FFB and FCB models' performances together, not 
+  # separately for each model.
   mse_90_pctl <- 
     quantile(frr_mse_spatial$mse, 
              na.rm = T, probs = .9) %>%
     unname()
   
   frr_mse_spatial %<>%
-    filter(mse <= mse_90_pctl) %>%
+    # Censor MSE values to the 90th percentile for visual clarity in mapping 
+    # Here, we take the minimum of each MSE observation and the 90th MSE pctile. 
+    # pmin() allows for element-wise comparisons of two vectors. So each entry in 
+    # the mse column (which is just a vector) will be compared to the 90th pctile
+    # value. In the map, this will render all outliers (>90th pctile) as the
+    # same colors as those at the 90th pctile, thereby not omitting them as gray
+    # county polygons
+    mutate(mse = pmin(mse, mse_90_pctl)) %>%
     na.omit()
   
   


### PR DESCRIPTION
Hi Seth,

I've tried to address your points about Fig 9's method of calculating the 90th ptile MSE value, as well as add some code that censoring values above the 90th ptile to the 90th ptile value. I've added a bunch of comments to hopefully clarify the workflow in that script. I realize upon revisit that it is difficult to read and poorly arranged. Since I could not actually test the new code I wrote on [line 134](https://github.com/binders1/fmv/compare/master...miriamasagold:fmv:master?expand=1#diff-85e9a1ac91b9b68858c542f68803c8b8746c530e6625d075bc022a01fe5bc49cR134), let me know if it produces any unexpected errors when you rerun the figure generation code. Happy to troubleshoot as we go.

Commit message for reference:
> Following up on email exchange from 30 June 2023, this commit clarifies how Fig 9 calculates the 90th percentile value (i.e., using a vector of both models' county level performances, not separately for each model) and implementing a censoring technique to convert any >90th percentile MSE observation to exactly the value at the 90th percentile.