### PR TITLE
R code mock up for figure comparing 2020 sale prices to previous years

### DIFF
--- a/code/viz/exhibit_fns/09_compare_ffb_fcb_mse.R
+++ b/code/viz/exhibit_fns/09_compare_ffb_fcb_mse.R
@@ -15,13 +15,15 @@ percent_change <- function(x1, x2) {
 
 compare_ffb_fcb_mse <- function() {
   
-  # Load FRR predictions (ffb) ####
+  # Load FRR predictions ####
   
   mods_to_load <- 
     c("ffb", "fcb", "ncb") %>%
     purrr::set_names()
   
   full_predictions <-
+    # Load in FFB, FCB, and NCB prediction dataframes, but keep them separate 
+    # for now
     map(
       mods_to_load,
       loadResults,
@@ -32,14 +34,16 @@ compare_ffb_fcb_mse <- function() {
       mutate(fips = str_sub(sid, 1, 5)) %>%
         select(fips, model, sid, .pred, log_priceadj_ha)
     )
+
   
-  # MSE in added counties
+  # Brief analysis aside to produce stats reported in the paper ----------------
+  
+  # 1. MSE in added counties
   full_predictions$ffb %>%
     filter(! fips %in% full_predictions$fcb$fips) %>%
     calc_mse()
-
   
-  # Compare fcb to ffb MSE across common parcels
+  # 2. Compare fcb to ffb MSE across common parcels
   ffb_ncb_common_parcels <-
     common_parcels(full_predictions[c("ffb", "ncb")])
   
@@ -52,30 +56,54 @@ compare_ffb_fcb_mse <- function() {
     map(calc_mse) %>%
     map("mean_mse")
   
-  # 15 percent change referenced in abstract and end of results section
+  # 15 percent change referenced in abstract and end of results section ->
     percent_change(x1 = mse_across_common_parcels$ncb, 
                    x2 = mse_across_common_parcels$ffb)
     
+  # ----------------------------------------------------------------------------  
     
+  
+  # Back to mapping FFB and FCB relative county coverage -----------------------    
     full_predictions <-
+      # Grab FFB and FCB from the list of model prediction dataframes...
       full_predictions[c("ffb", "fcb")] %>%
+      # ...and row-bind them together, filling in missing county observations with
+      # NAs if one model includes that county but the other does not
       data.table::rbindlist(fill = TRUE) %>%
+      
+      # Calculate MSE 
       mutate(sq_error = (.pred - log_priceadj_ha)^2) %>%
       group_by(fips, model) %>%
       mutate(mse = mean(sq_error)) %>%
       ungroup() %>%
       select(model, fips, mse) %>%
+      
+      # Clean up model names
       mutate(model = if_else(model=="ffb", "Full FRR", "Full County")) %>%
       distinct()
     
     frr_missing_obs <-
       full_predictions %>%
+      
+      # We start with a column called "model" that identifies which model 
+      # a given prediction came up. Now we pivot that column, along with the 
+      # MSE values, to create 2 columns: one for FFB and one for FCB, each 
+      # containing the corresponding MSE values in that county. This allows us
+      # to determine which counties are not in the FRR model's test set (which
+      # is where these predictions come from) but are by definition included in
+      # the county's test set, since each county gets its own test and train set
+      # Only a handful of counties are absent from the FRR test set in this way. 
+      # We plot them at black and note the quirk of our modeling approach in the 
+      # figure caption
       pivot_wider(
         names_from = model,
         values_from = mse
       ) %>%
+      # This filter call keeps only those *counties* which are missing from the 
+      # FRR model in the manner described in the above comment
       filter(is.na(`Full FRR`)) %>%
       select(fips) %>%
+      # Join to the counties shapefile for later mapping in black.
       left_join(us_counties,
                 by = "fips") %>%
       st_as_sf()
@@ -87,13 +115,23 @@ compare_ffb_fcb_mse <- function() {
     
     mutate(mse_b = cut(mse, breaks = c(0, 0.5, 1, 5, 40)))
   
+  # The 90th percentile is calculated relative to the vector of *all* county
+  # MSEs. That is, the FFB and FCB models' performances together, not 
+  # separately for each model.
   mse_90_pctl <- 
     quantile(frr_mse_spatial$mse, 
              na.rm = T, probs = .9) %>%
     unname()
   
   frr_mse_spatial %<>%
-    filter(mse <= mse_90_pctl) %>%
+    # Censor MSE values to the 90th percentile for visual clarity in mapping 
+    # Here, we take the minimum of each MSE observation and the 90th MSE pctile. 
+    # pmin() allows for element-wise comparisons of two vectors. So each entry in 
+    # the mse column (which is just a vector) will be compared to the 90th pctile
+    # value. In the map, this will render all outliers (>90th pctile) as the
+    # same colors as those at the 90th pctile, thereby not omitting them as gray
+    # county polygons
+    mutate(mse = pmin(mse, mse_90_pctl)) %>%
     na.omit()
   
   

--- a/code/viz/exhibit_fns/S4_avgprice_compare_2020.R
+++ b/code/viz/exhibit_fns/S4_avgprice_compare_2020.R
@@ -1,0 +1,83 @@
+
+avgprice_compare_2020 <- function() {
+  
+  # State abbreviations
+  all_states <-
+    list.files(
+      clean_dir,
+      full.names = FALSE,
+      pattern = "pqt$"
+    ) %>%
+    str_extract("[A-Z]{2}(?=\\.pqt$)") %>%
+    sort()
+  
+  # Load all cleaned sales observations by state and row-bind them into a 
+  # single dataframe
+  clean_sale_data <-
+    map_dfr(
+      all_states,
+      read_state_clean
+    )
+  
+  # Aggregate by year and month
+  clean_data_price_by_yrmon <-
+    clean_sale_data %>%
+    
+    # Extract year and month from sale dates
+    mutate(
+      year = lubridate::year(date),
+      month = lubridate::month(date, label = TRUE)
+    ) %>%
+    
+    # If you want to convert the prices back to levels, uncomment this line:
+    # (you will also have to rename the variable in the summarise function below)
+    # mutate(priceadj_ha = exp(log_priceadj_ha), priceadj = priceadj_ha*ha) %>%
+    # Aggregate average sale price by year-month
+    dplyr::group_by(year, month) %>%
+    summarise(
+      mean_price_by_yrmon = mean(log_priceadj_ha, na.rm = TRUE)
+    ) %>%
+    
+    # Convert month to factor, and create indicator for 2020, to allow 
+    # 2020 line to be highlighted in the plot below
+    mutate(
+      month = factor(month),
+      is_2020 = if_else(year == 2020, "2020", "2000-2019")
+    )
+  
+  # Plot avg price against month, with lines for each year
+  clean_data_price_by_yrmon %>%
+    
+    ggplot(
+      aes(
+        x = month,
+        y = mean_price_by_yrmon, 
+        # Differentiate 2020 line by color and size, customized below
+        color = is_2020,
+        size = is_2020,
+        group = year)
+    ) +
+    
+    geom_line() +
+    
+    scale_color_manual(
+      values = c(
+        `2020` = "#33A02C",
+        `2000-2019` = "grey"
+      )
+    ) +
+    scale_size_manual(
+      values = c(
+        `2020` = 1.5,
+        `2000-2019` = 0.75
+      )
+    ) +
+    labs(
+      x = NULL,
+      y = "Average Sale Price (log)",
+      color = NULL,
+      size = NULL
+    ) +
+    fmv_theme
+
+}

--- a/code/viz/master_viz.R
+++ b/code/viz/master_viz.R
@@ -107,7 +107,8 @@ exhibit_tbl_plos_one <-
   "Fig11"  , cost_effective_30by30   , "tiff" , 8     , 4      , "lzw",
   "S1"     , fcb_importance_all      , "tiff" , 7     , 4      , "lzw",
   "S2"     , ffb_importance_all      , "tiff" , 7     , 4      , "lzw",
-  "S3"     , frr_performance_size    , "tiff" , 8     , 4      , "lzw"
+  "S3"     , frr_performance_size    , "tiff" , 8     , 4      , "lzw",
+  "S4"     , avgprice_compare_2020   , "tiff" , 8     , 4      , "lzw"
   ) 
 
 #exhibit_tbl_plos_one %<>% slice(2)


### PR DESCRIPTION
Seth, here's some R code that should get you most of the way there in creating the average sale price figure by month with lines for each year in the analysis (2020 being highlighted). 

Feel free to edit as you see fit. The function `avgprice_compare_2020()` can be run interactively on its own, or along with all the other PLOS One figures in `master_viz.R`